### PR TITLE
handle request.get throwing when fetching release text

### DIFF
--- a/BandcampReleaseSummary.py
+++ b/BandcampReleaseSummary.py
@@ -172,7 +172,7 @@ def scrape_info_from_bc_page(release):
         html_text = requests.get(release_url).text
     except Exception as e:
         html_text = ""
-        print(f'Error getting fetching release data at {release_url}: {e}')
+        print(f'Error fetching release data at {release_url}: {e}')
 
     soup = BeautifulSoup(html_text, 'html.parser')
 

--- a/BandcampReleaseSummary.py
+++ b/BandcampReleaseSummary.py
@@ -168,7 +168,12 @@ def scrape_info_from_email(email_text):
 def scrape_info_from_bc_page(release):
     release_url = release['url']
 
-    html_text = requests.get(release_url).text
+    try:
+        html_text = requests.get(release_url).text
+    except Exception as e:
+        html_text = ""
+        print(f'Error getting fetching release data at {release_url}: {e}')
+
     soup = BeautifulSoup(html_text, 'html.parser')
 
     # release title


### PR DESCRIPTION
Occasionally `requests.get` will fail (page no longer exists, network error etc), and the unhandled error will cause the program to panic and terminate. As a safeguard, I’ve wrapped it in try/except block, rendering the text as an empty string in the case it fails to prevent the entire program from crashing.